### PR TITLE
Add support for Wagtail 2.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,23 +32,8 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py36-dj111-wag113
-            - py36-dj111-wag23
-            - py36-dj20-wag23 
-            - py36-dj22-wag23
-            - py36-dj22-wag28 
             - py38-dj22-wag28
         include:
-          - toxenv: py36-dj111-wag113
-            python-version: 3.6
-          - toxenv: py36-dj111-wag23 
-            python-version: 3.6
-          - toxenv: py36-dj20-wag23 
-            python-version: 3.6
-          - toxenv: py36-dj22-wag23
-            python-version: 3.6
-          - toxenv: py36-dj22-wag28
-            python-version: 3.6
           - toxenv: py38-dj22-wag28
             python-version: 3.8
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
@@ -32,29 +32,25 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py27-dj111-wag113
             - py36-dj111-wag113
-            - py36-dj111-wag22
-            - py36-dj21-wag24
-            - py36-dj21-wag23 
-            - py36-dj21-wag24 
-            - py36-dj22-wag25 
-            - py37-dj22-wag25
+            - py36-dj111-wag23
+            - py36-dj20-wag23 
+            - py36-dj22-wag23
+            - py36-dj22-wag28 
+            - py38-dj22-wag28
         include:
-          - toxenv: py27-dj111-wag113
-            python-version: 2.7
           - toxenv: py36-dj111-wag113
             python-version: 3.6
-          - toxenv: py36-dj21-wag24
+          - toxenv: py36-dj111-wag23 
             python-version: 3.6
-          - toxenv: py36-dj21-wag23 
+          - toxenv: py36-dj20-wag23 
             python-version: 3.6
-          - toxenv: py36-dj21-wag24 
+          - toxenv: py36-dj22-wag23
             python-version: 3.6
-          - toxenv: py36-dj22-wag25 
+          - toxenv: py36-dj22-wag28
             python-version: 3.6
-          - toxenv: py37-dj22-wag25
-            python-version: 3.7
+          - toxenv: py38-dj22-wag28
+            python-version: 3.8
 
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ CopyableModelAdmin is an extension of the [Wagtail ModelAdmin](https://docs.wagt
 
 ## Dependencies
 
-- Python 3.6+
-- Django 1.11+, 2.0+
-- Wagtail 1.13+, 2.0+
+- Python 3.8
+- Django 2.2
+- Wagtail 2.8
 
 ## Installation
 

--- a/copyablemodeladmin/tests/settings.py
+++ b/copyablemodeladmin/tests/settings.py
@@ -4,8 +4,6 @@ import os
 
 import django
 
-import wagtail
-
 
 DEBUG = True
 
@@ -32,58 +30,31 @@ DATABASES = {
     },
 }
 
-if wagtail.VERSION >= (2, 0):
-    WAGTAIL_APPS = (
-        'wagtail.contrib.forms',
-        'wagtail.contrib.modeladmin',
-        'wagtail.contrib.settings',
-        'wagtail.tests.testapp',
-        'wagtail.admin',
-        'wagtail.core',
-        'wagtail.documents',
-        'wagtail.images',
-        'wagtail.sites',
-        'wagtail.users',
-    )
+WAGTAIL_APPS = (
+    'wagtail.contrib.forms',
+    'wagtail.contrib.modeladmin',
+    'wagtail.contrib.settings',
+    'wagtail.tests.testapp',
+    'wagtail.admin',
+    'wagtail.core',
+    'wagtail.documents',
+    'wagtail.images',
+    'wagtail.sites',
+    'wagtail.users',
+)
 
-    WAGTAIL_MIDDLEWARE = (
-        'wagtail.core.middleware.SiteMiddleware',
-    )
+WAGTAIL_MIDDLEWARE = (
+    'wagtail.core.middleware.SiteMiddleware',
+)
 
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        'default': {
-            'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea'
-        },
-        'custom': {
-            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
-        },
-    }
-else:
-    WAGTAIL_APPS = (
-        'wagtail.contrib.modeladmin',
-        'wagtail.contrib.settings',
-        'wagtail.tests.testapp',
-        'wagtail.wagtailadmin',
-        'wagtail.wagtailcore',
-        'wagtail.wagtaildocs',
-        'wagtail.wagtailforms',
-        'wagtail.wagtailimages',
-        'wagtail.wagtailsites',
-        'wagtail.wagtailusers',
-    )
-
-    WAGTAIL_MIDDLEWARE = (
-        'wagtail.wagtailcore.middleware.SiteMiddleware',
-    )
-
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        'default': {
-            'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea',
-        },
-        'custom': {
-            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
-        },
-    }
+WAGTAILADMIN_RICH_TEXT_EDITORS = {
+    'default': {
+        'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea'
+    },
+    'custom': {
+        'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+    },
+}
 
 if django.VERSION >= (1, 10):
     MIDDLEWARE = (

--- a/copyablemodeladmin/tests/urls.py
+++ b/copyablemodeladmin/tests/urls.py
@@ -1,12 +1,6 @@
 from django.conf.urls import include, url
 
-import wagtail
-
-
-if wagtail.VERSION >= (2, 0):
-    from wagtail.admin import urls as wagtailadmin_urls
-else:
-    from wagtail.wagtailadmin import urls as wagtailadmin_urls
+from wagtail.admin import urls as wagtailadmin_urls
 
 
 urlpatterns = [

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 from setuptools import find_packages, setup
 
 
-long_description = open('README.md', 'r').read()
-
 install_requires = [
-    'wagtail>=1.13,<2.8',
+    'wagtail>=1.13,<2.9',
 ]
 
 testing_extras = [
@@ -18,10 +16,10 @@ setup(
     author='CFPB',
     author_email='tech@cfpb.gov',
     description='Copyable ModelAdmins for Django models used on Wagtail Sites',
-    long_description=long_description,
+    long_description=open('README.md', 'r').read(),
     long_description_content_type='text/markdown',
     license='CC0',
-    version='1.0.0',
+    version='1.0.1',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,
@@ -32,7 +30,6 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
@@ -41,7 +38,5 @@ setup(
         'License :: Public Domain',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'wagtail>=1.13,<2.9',
+    'wagtail>=2.0,<2.9',
 ]
 
 testing_extras = [
@@ -19,7 +19,7 @@ setup(
     long_description=open('README.md', 'r').read(),
     long_description_content_type='text/markdown',
     license='CC0',
-    version='1.0.1',
+    version='1.1.0',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,
@@ -28,11 +28,8 @@ setup(
     },
     classifiers=[
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 2',
         'Framework :: Wagtail',
-        'Framework :: Wagtail :: 1',
         'Framework :: Wagtail :: 2',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj{111}-wag{113},
-    py{36}-dj{111,20}-wag{23},
-    py{36,38}-dj{22}-wag{28}
+    py{38}-dj{22}-wag{28}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -16,16 +14,10 @@ setenv=
     DJANGO_SETTINGS_MODULE=copyablemodeladmin.tests.settings
 
 basepython=
-    py36: python3.6
     py38: python3.8
 
 deps=
-    dj111: Django>=1.11,<1.12
-    dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
-    wag113: wagtail>=1.13,<1.14
-    wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ skipsdist=True
 envlist=
     lint,
     py{36}-dj{111}-wag{113},
-    py{36}-dj{111,20}-wag{22},
-    py{36,37}-dj{22}-wag{27}
+    py{36}-dj{111,20}-wag{23},
+    py{36,38}-dj{22}-wag{28}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -16,21 +16,20 @@ setenv=
     DJANGO_SETTINGS_MODULE=copyablemodeladmin.tests.settings
 
 basepython=
-    py27: python2.7
     py36: python3.6
-    py37: python3.7
+    py38: python3.8
 
 deps=
     dj111: Django>=1.11,<1.12
+    dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
-    wag22: wagtail>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
-    wag24: wagtail>=2.4,<2.5
+    wag28: wagtail>=2.8,<2.9
 
 [testenv:lint]
-basepython=python3.7
+basepython=python3.8
 deps=
     flake8>=2.2.0
     isort>=4.2.15
@@ -55,6 +54,6 @@ not_skip=__init__.py
 use_parentheses=1
 known_django=django
 known_wagtail=wagtail
-known_future_library=future,six
+known_future_library=future
 default_section=THIRDPARTY
 sections=FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
Create version 1.1.0 to support Wagtail 2.8 and Python 3.8

## Additions

- Wagtail 2.8 and Python 3.8 from `tox.ini`

## Removals

- six, Python 2.7 and Python 3.7 from `tox.ini`

## Testing

1. tox

```
...
py38-dj22-wag28 run-test: commands[0] | coverage erase
py38-dj22-wag28 run-test: commands[1] | coverage run --source=copyablemodeladmin /Users/DaviesC/Projects/CFPB/wagtail-copyablemodeladmin/.tox/py38-dj22-wag28/bin/django-admin.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..
----------------------------------------------------------------------
Ran 2 tests in 0.399s

OK
Destroying test database for alias 'default'...
py38-dj22-wag28 run-test: commands[2] | coverage report -m
Name                                                        Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------
copyablemodeladmin/__init__.py                                  0      0   100%
copyablemodeladmin/helpers.py                                  19      0   100%
copyablemodeladmin/options.py                                  17      0   100%
copyablemodeladmin/tests/__init__.py                            0      0   100%
copyablemodeladmin/tests/copyabletestapp/__init__.py            0      0   100%
copyablemodeladmin/tests/copyabletestapp/models.py              5      1    80%   8
copyablemodeladmin/tests/copyabletestapp/wagtail_hooks.py      16      0   100%
copyablemodeladmin/tests/settings.py                           18      1    94%   69
copyablemodeladmin/tests/test_options.py                       20      0   100%
copyablemodeladmin/tests/urls.py                                3      0   100%
copyablemodeladmin/views.py                                    13      0   100%
-----------------------------------------------------------------------------------------
TOTAL                                                         111      2    98%
_______________________________________________ summary ________________________________________________
  lint: commands succeeded
  py38-dj22-wag28: commands succeeded
  congratulations :)
```

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: